### PR TITLE
fix(make): use correct mnt points

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ HOST_OS = $(shell uname -s)
 # Mount point and boot partition
 FLASH_DEFAULT_TARGET = chainloader
 MNT = $(MNT_$(HOST_OS))
-MNT_Linux  = build/mnt
+MNT_Linux  = mnt
 MNT_Darwin = /Volumes/boot
 #BOOT_PART = /dev/mmcblk0p1
 

--- a/chainloader/Makefile
+++ b/chainloader/Makefile
@@ -17,7 +17,7 @@ LOPS   = -ffreestanding -nostdlib
 
 # Mount point and boot partition
 MNT = $(MNT_$(HOST_OS))
-MNT_Linux  = build/mnt
+MNT_Linux  = ../mnt
 MNT_Darwin = /Volumes/boot
 
 # Serial connection config

--- a/thorn/Makefile
+++ b/thorn/Makefile
@@ -17,7 +17,7 @@ LOPS   = -ffreestanding -nostdlib
 
 # Mount point and boot partition
 MNT = $(MNT_$(HOST_OS))
-MNT_Linux  = build/mnt
+MNT_Linux  = ../mnt
 MNT_Darwin = /Volumes/boot
 
 # Serial connection config


### PR DESCRIPTION
BREAKING CHANGE:

`/etc/fstab` requires an entry mounting the boot partition of the sdcard
to $(PROJECT_ROOT_DIR)/mnt