### PR TITLE
fix(font): fix off-by-one error when printing tabs

### DIFF
--- a/thorn/src/common/font.c
+++ b/thorn/src/common/font.c
@@ -163,7 +163,6 @@ void printc (char c) {
             cursor.y += FONT_REAL_HEIGHT;
             break;
         case '\t':// Print minimum one space, then align forwards to tab grid
-            cursor.x = cursor.x + FONT_REAL_WIDTH;
             cursor.x += FONT_TAB_REAL_WIDTH - cursor.x % (FONT_TAB_REAL_WIDTH);
             break;
         default:// Print character and update cursor


### PR DESCRIPTION
The expression `FONT_TAB_REAL_WIDTH - cursor.x % (FONT_TAB_REAL_WIDTH)` already evaluates to [1..4] (for a tab width of 4). Therefore we don't need to add an explicit additional space.