### PR TITLE
feat(flash): handle SD card being already mounted

### DIFF
--- a/chainloader/Makefile
+++ b/chainloader/Makefile
@@ -92,7 +92,7 @@ flash: flash-$(HOST_OS)
 
 flash-Linux: $(IMAGE_NAME).img
 	mkdir -p $(MNT)
-	@mount $(MNT) && echo "mounted SD card to $(MNT)" || echo "mount failed, expecting card to be already mounted, continuing..."
+	@mount $(MNT) && echo "mounted SD card to $(MNT)" || echo "Warning: mount failed, expecting card to be already mounted, continuing..."
 	cp $(IMAGE_NAME).img $(MNT)/kernel8.img
 	cp $(SRC)/config.txt $(MNT)
 	sync

--- a/chainloader/Makefile
+++ b/chainloader/Makefile
@@ -92,7 +92,7 @@ flash: flash-$(HOST_OS)
 
 flash-Linux: $(IMAGE_NAME).img
 	mkdir -p $(MNT)
-	mount $(MNT)
+	@mount $(MNT) && echo "mounted SD card to $(MNT)" || echo "mount failed, expecting card to be already mounted, continuing..."
 	cp $(IMAGE_NAME).img $(MNT)/kernel8.img
 	cp $(SRC)/config.txt $(MNT)
 	sync

--- a/chainloader/Makefile
+++ b/chainloader/Makefile
@@ -92,7 +92,7 @@ flash: flash-$(HOST_OS)
 
 flash-Linux: $(IMAGE_NAME).img
 	mkdir -p $(MNT)
-	@mount $(MNT) && echo "mounted SD card to $(MNT)" || echo "Warning: mount failed, expecting card to be already mounted, continuing..."
+	@mount $(MNT) && echo "mounted SD card to $(MNT)" || echo "Warning: mount failed, assuming card to be already properly mounted"
 	cp $(IMAGE_NAME).img $(MNT)/kernel8.img
 	cp $(SRC)/config.txt $(MNT)
 	sync

--- a/chainloader/Makefile
+++ b/chainloader/Makefile
@@ -92,7 +92,7 @@ flash: flash-$(HOST_OS)
 
 flash-Linux: $(IMAGE_NAME).img
 	mkdir -p $(MNT)
-	@mount $(MNT) && echo "mounted SD card to $(MNT)" || echo "Warning: mount failed, assuming card to be already properly mounted"
+	@mount $(MNT) && echo "mounted SD card to $(MNT)" || echo "Warning: mount failed, assuming card to already be properly mounted on $(MNT)"
 	cp $(IMAGE_NAME).img $(MNT)/kernel8.img
 	cp $(SRC)/config.txt $(MNT)
 	sync


### PR DESCRIPTION
This will make this the `make flash` output on successful mounting:

```
make -C chainloader flash
make[1]: Entering directory '/home/kjell/git/rose/chainloader'
aarch64-none-elf-ld -T src/linker.ld -o build/chainloader.elf  build/src/kernel/kernel_c.o  build/src/kernel/load_c.o  build/src/kernel/mailbox_c.o  build/src/kernel/mini_uart_c.o  build/src/kernel/boot_S.o  build/src/common/status_led_c.o  build/src/common/utils_S.o
aarch64-none-elf-objcopy build/chainloader.elf -O binary chainloader.img
mkdir -p ../mnt
mounted SD card to ../mnt
cp chainloader.img ../mnt/kernel8.img
cp src/config.txt ../mnt
sync
sleep 1
umount ../mnt
make[1]: Leaving directory '/home/kjell/git/rose/chainloader'
```

And this the output when mounting fails:

```
make -C chainloader flash
make[1]: Entering directory '/home/kjell/git/rose/chainloader'
aarch64-none-elf-ld -T src/linker.ld -o build/chainloader.elf  build/src/kernel/kernel_c.o  build/src/kernel/load_c.o  build/src/kernel/mailbox_c.o  build/src/kernel/mini_uart_c.o  build/src/kernel/boot_S.o  build/src/common/status_led_c.o  build/src/common/utils_S.o
aarch64-none-elf-objcopy build/chainloader.elf -O binary chainloader.img
mkdir -p ../mnt
mount: /home/kjell/git/rose/mnt: /dev/mmcblk0p1 already mounted on /home/kjell/git/rose/mnt.
mount failed, expecting card to be already mounted, continuing...
cp chainloader.img ../mnt/kernel8.img
cp src/config.txt ../mnt
sync
sleep 1
umount ../mnt
make[1]: Leaving directory '/home/kjell/git/rose/chainloader'
```