### PR TITLE
chore(make): select tty console based on what's installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ send-thorn: setup-serial-$(HOST_OS)
 
 # Set up screen on alternate serial port
 screen:
-	screen $(SERIAL_PORT_ALT) $(BAUD_RATE)
+	minicom -D $(SERIAL_PORT_ALT) -b $(BAUD_RATE) || screen $(SERIAL_PORT_ALT) $(BAUD_RATE)
 
 poweroff:
 	printf "0: %.2x" 17 | xxd -re -g0 > $(SERIAL_PORT)

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ send-thorn: setup-serial-$(HOST_OS)
 
 # Set up screen on alternate serial port
 screen:
-	minicom -D $(SERIAL_PORT_ALT) -b $(BAUD_RATE) || screen $(SERIAL_PORT_ALT) $(BAUD_RATE)
+	picocom -b $(BAUD_RATE) $(SERIAL_PORT_ALT) || screen $(SERIAL_PORT_ALT) $(BAUD_RATE)
 
 poweroff:
 	printf "0: %.2x" 17 | xxd -re -g0 > $(SERIAL_PORT)

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ send-thorn: setup-serial-$(HOST_OS)
 
 # Set up screen on alternate serial port
 screen:
-	picocom -b $(BAUD_RATE) $(SERIAL_PORT_ALT) || screen $(SERIAL_PORT_ALT) $(BAUD_RATE)
+	picocom -b $(BAUD_RATE) $(SERIAL_PORT_ALT) || minicom -D $(SERIAL_PORT_ALT) -b $(BAUD_RATE) || screen $(SERIAL_PORT_ALT) $(BAUD_RATE)
 
 poweroff:
 	printf "0: %.2x" 17 | xxd -re -g0 > $(SERIAL_PORT)

--- a/README.md
+++ b/README.md
@@ -5,13 +5,22 @@ tutorial: https://github.com/s-matyukevich/raspberry-pi-os.git
 
 # How to cable
 
-Plug in the black cables of each serial cable into a Ground pin on the Pi (for example pin 6 and 14).
+Plug the black wires of each serial cable onto a Ground pin on the Pi (for example pin 6 and 14).
 
-Then **white** of one cable to 8 (GPIO 14 / TXD)  
-Then **green** of the other cable to 10 (GPIO 15 / RXD)
+Then the **white** wire of one cable to 8 (GPIO 14 / TXD)  
+Then the **green** wire of the other cable to 10 (GPIO 15 / RXD)
 
-The serial cable with **white** connected is transmitting to the computer and has to be plugged into the computer first. It has to show up as `/dev/ttyUSB0`.  
-The **green** one is receiving on the Raspberry Pi and has to be `/dev/ttyUSB1`.
+The serial cable with the **white** wire connected is transmitting to the computer and has to be plugged into the computer first. It has to show up as `/dev/ttyUSB0`.  
+The **green** wire is the one receiving on the Raspberry Pi and has to be `/dev/ttyUSB1`.
+
+You can read the Pi's output from the white cable by executing `make screen`.
+Which launches screen, connected to the serial port. However due to its
+blocking nature we have to give it a separate cable.
+
+If you have installed `picocom` or `minicom` as an alternative to `screen` then you
+actually only need one serial cable of which you can then connect both the
+green and the white wire. `make screen` will then prioritize them over
+`screen`.
 
 ### MacOS cable setup:
 

--- a/thorn/src/kernel/kernel.c
+++ b/thorn/src/kernel/kernel.c
@@ -26,15 +26,6 @@ void user_process1 (char * array) {
     }
 }
 
-void user_process_rng () {
-    char buf[2] = {0};
-    while (1) {
-        buf[0] = random ();
-        call_sys_write (buf);
-        delay (100000);
-    }
-}
-
 void user_process () {
     char buf[30] = {0};
     tfp_sprintf (buf, "User process started\n\r");
@@ -57,16 +48,6 @@ void user_process () {
     err = call_sys_clone ((unsigned long) &user_process1, (unsigned long) "abcd", stack);
     if (err < 0) {
         printf ("Error while cloning process 2\n\r");
-        return;
-    }
-    stack = call_sys_malloc ();
-    if (stack < 0) {
-        printf ("Error while allocating stack for process 3\n\r");
-        return;
-    }
-    err = call_sys_clone ((unsigned long) &user_process_rng, 0, stack);
-    if (err < 0) {
-        printf ("Error while cloning process 3\n\r");
         return;
     }
     call_sys_exit ();


### PR DESCRIPTION
There are different tools we can use to connect to the raspberry via UART.
This implementation selects a tty monitor based on what's installed in the following order:
1. `picocom`
2. `minicom`
3. `screen`

NOTE: screen does NOT allow concurrent monitoring of the raspberry AND sending of the kernel to the chainloader or special commands to thorn