### PR TITLE
feat(thorn): detect if SD is already mounted

### DIFF
--- a/thorn/Makefile
+++ b/thorn/Makefile
@@ -92,7 +92,7 @@ flash: flash-$(HOST_OS)
 
 flash-Linux: $(IMAGE_NAME).img
 	mkdir -p $(MNT)
-	mount $(MNT)
+	@mount $(MNT) && echo "mounted SD card to $(MNT)" || echo "Warning: mount failed, assuming card to already be properly mounted on $(MNT)"
 	cp $(IMAGE_NAME).img $(MNT)/kernel8.img
 	cp $(SRC)/config.txt $(MNT)
 	sync


### PR DESCRIPTION
This was already added to the chainloader, however we actually do also
need it here since we do sometimes want to flash thorn directly to the
SD card